### PR TITLE
respond in Response rather than in JSend

### DIFF
--- a/src/AbstractJSendResponse.php
+++ b/src/AbstractJSendResponse.php
@@ -69,9 +69,9 @@ abstract class AbstractJSendResponse implements JSendResponseInterface
     }
 
     /**
-     *
+     * @param int|null $code
      */
-    public function respond(): void
+    public function respond(int $code = null): void
     {
         $code = $code ?? JSend::getDefaultHttpStatusCode($this);
         ensure($code)->isInt()->isBetween(100, 511);

--- a/src/AbstractJSendResponse.php
+++ b/src/AbstractJSendResponse.php
@@ -2,6 +2,8 @@
 
 namespace Demv\JSend;
 
+use function Dgame\Ensurance\ensure;
+
 /**
  * Class AbstractJSendResponse
  * @package Demv\JSend
@@ -64,5 +66,18 @@ abstract class AbstractJSendResponse implements JSendResponseInterface
     public function jsonSerialize(): array
     {
         return $this->asArray();
+    }
+
+    /**
+     *
+     */
+    public function respond(): void
+    {
+        $code = $code ?? JSend::getDefaultHttpStatusCode($this);
+        ensure($code)->isInt()->isBetween(100, 511);
+
+        header('Content-Type: application/json; charset="UTF-8"', true, $code);
+        print json_encode($this);
+        exit;
     }
 }

--- a/src/JSend.php
+++ b/src/JSend.php
@@ -76,18 +76,4 @@ final class JSend
 
         return 200;
     }
-
-    /**
-     * @param JSendResponseInterface $response
-     * @param int|null               $code
-     */
-    public static function respondWith(JSendResponseInterface $response, int $code = null): void
-    {
-        $code = $code ?? self::getDefaultHttpStatusCode($response);
-        ensure($code)->isInt()->isBetween(100, 511);
-
-        header('Content-Type: application/json; charset="UTF-8"', true, $code);
-        print json_encode($response);
-        exit;
-    }
 }

--- a/src/JSendResponseInterface.php
+++ b/src/JSendResponseInterface.php
@@ -26,7 +26,7 @@ interface JSendResponseInterface extends JsonSerializable
     public function getError(): JSendErrorResponseInterface;
 
     /**
-     *
+     * @param int|null $code
      */
-    public function respond(): void;
+    public function respond(int $code = null): void;
 }

--- a/src/JSendResponseInterface.php
+++ b/src/JSendResponseInterface.php
@@ -24,4 +24,9 @@ interface JSendResponseInterface extends JsonSerializable
      * @return JSendErrorResponseInterface
      */
     public function getError(): JSendErrorResponseInterface;
+
+    /**
+     *
+     */
+    public function respond(): void;
 }


### PR DESCRIPTION
Dann geht
```php
ResponseFactory::instance()->success([...])->respond();
```
statt
```php
JSend::respondWith(ResponseFactory::instance()->success([...]));
```