### PR TITLE
Helper - Closes #6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -318,16 +318,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -365,7 +365,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27T17:38:31+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -728,16 +728,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.3",
+            "version": "6.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4"
+                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/882e886cc928a0abd3c61282b2a64026237d14a4",
-                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3330ef26ade05359d006041316ed0fa9e8e3cefe",
+                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe",
                 "shasum": ""
             },
             "require": {
@@ -755,7 +755,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.4",
+                "phpunit/phpunit-mock-objects": "^5.0.5",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -808,27 +808,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:42:03+00:00"
+            "time": "2018-02-01T05:57:37+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.4",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a"
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
-                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
                 "php": "^7.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
                 "phpunit/phpunit": "<6.0"
@@ -867,7 +867,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-12-02T05:31:19+00:00"
+            "time": "2018-01-06T05:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -916,21 +916,21 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
-                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^2.0 || ^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
@@ -976,7 +976,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-11-03T07:16:52+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1470,16 +1470,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1516,7 +1516,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         }
     ],
     "aliases": [],

--- a/src/JSend.php
+++ b/src/JSend.php
@@ -18,9 +18,9 @@ final class JSend
      */
     private static function interpret(array $response): JSendResponseInterface
     {
-        ensure($response)->isArray()->hasKey('status')->orThrow('Key "status" is required');
+        ensure($response)->isArray()->hasKey(StatusInterface::KEY)->orThrow('Key "status" is required');
 
-        $status = new Status($response['status']);
+        $status = Status::instance($response[StatusInterface::KEY]);
         if ($status->isSuccess() || $status->isFail()) {
             ensure($response)->isArray()->hasKey('data')->orThrow('Key "data" is required');
 
@@ -47,19 +47,54 @@ final class JSend
 
     /**
      * @param array $response
-     * @param int   $options
      *
      * @return string
      */
-    public static function encode(array $response, int $options = 0): string
+    public static function encode(array $response): string
     {
         ensure($response)->isNotEmpty()->orThrow('Empty response cannot be converted to valid JSend-JSON');
-        ensure($response)->isArray()->hasKey('status')->orThrow('Key "status" is required');
-        $status    = new Status($response['status']);
+        ensure($response)->isArray()->hasKey(StatusInterface::KEY)->orThrow('Key "status" is required');
+        $status = Status::instance($response[StatusInterface::KEY]);
         if ($status->isError()) {
             ensure($response)->isArray()->hasKey('message')->orThrow('Need a descriptive error-message');
         }
 
-        return json_encode($response, $options);
+        return json_encode($response);
+    }
+
+    /**
+     * @param array $response
+     *
+     * @return string
+     */
+    public static function success(array $response): string
+    {
+        $response[StatusInterface::KEY] = StatusInterface::STATUS_SUCCESS;
+
+        return self::encode($response);
+    }
+
+    /**
+     * @param array $response
+     *
+     * @return string
+     */
+    public static function fail(array $response): string
+    {
+        $response[StatusInterface::KEY] = StatusInterface::STATUS_FAIL;
+
+        return self::encode($response);
+    }
+
+    /**
+     * @param array $response
+     *
+     * @return string
+     */
+    public static function error(array $response): string
+    {
+        $response[StatusInterface::KEY] = StatusInterface::STATUS_ERROR;
+
+        return self::encode($response);
     }
 }

--- a/src/StatusInterface.php
+++ b/src/StatusInterface.php
@@ -8,6 +8,7 @@ namespace Demv\JSend;
  */
 interface StatusInterface
 {
+    const KEY            = 'status';
     const STATUS_SUCCESS = 'success';
     const STATUS_FAIL    = 'fail';
     const STATUS_ERROR   = 'error';

--- a/tests/JSendBasicTest.php
+++ b/tests/JSendBasicTest.php
@@ -162,4 +162,25 @@ final class JSendBasicTest extends TestCase
         $this->assertEquals('Unable to communicate with database', $response->getError()->getMessage());
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
+
+    public function testSuccess()
+    {
+        $this->assertTrue(Status::success()->isSuccess());
+        $json = '{"status": "success", "data": null}';
+        $this->assertJsonStringEqualsJsonString($json, JSend::success(['data' => null]));
+    }
+
+    public function testFail()
+    {
+        $this->assertTrue(Status::fail()->isFail());
+        $json = '{"status": "fail", "data": null}';
+        $this->assertJsonStringEqualsJsonString($json, JSend::fail(['data' => null]));
+    }
+
+    public function testError()
+    {
+        $this->assertTrue(Status::error()->isError());
+        $json = '{"status": "error", "message": ""}';
+        $this->assertJsonStringEqualsJsonString($json, JSend::error(['message' => '']));
+    }
 }

--- a/tests/JSendBasicTest.php
+++ b/tests/JSendBasicTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class JSendBasicTest extends TestCase
 {
-    public function testEncodeSuccess()
+    public function testEncodeSuccess(): void
     {
         $json = '{
             "status" : "success",
@@ -37,7 +37,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, $result);
     }
 
-    public function testEncodeError()
+    public function testEncodeError(): void
     {
         $json = '{
             "status" : "error",
@@ -48,7 +48,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, $result);
     }
 
-    public function testEncodeErrorWithoutMessage()
+    public function testEncodeErrorWithoutMessage(): void
     {
         $this->expectException(EnsuranceException::class);
         $this->expectExceptionMessage('Need a descriptive error-message');
@@ -56,7 +56,7 @@ final class JSendBasicTest extends TestCase
         JSend::encode(['status' => 'error']);
     }
 
-    public function testEncodeEmpty()
+    public function testEncodeEmpty(): void
     {
         $this->expectException(EnsuranceException::class);
         $this->expectExceptionMessage('Empty response cannot be converted to valid JSend-JSON');
@@ -64,7 +64,7 @@ final class JSendBasicTest extends TestCase
         JSend::encode([]);
     }
 
-    public function testEncodeWithoutStatus()
+    public function testEncodeWithoutStatus(): void
     {
         $this->expectException(EnsuranceException::class);
         $this->expectExceptionMessage('Key "status" is required');
@@ -72,7 +72,7 @@ final class JSendBasicTest extends TestCase
         JSend::encode(['msg' => 'Foo']);
     }
 
-    public function testSuccessResponse()
+    public function testSuccessResponse(): void
     {
         $json = '{
             "status" : "success",
@@ -103,7 +103,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
 
-    public function testSuccessResponseWithoutData()
+    public function testSuccessResponseWithoutData(): void
     {
         $json = '{ "status": "success" }';
         $this->expectException(EnsuranceException::class);
@@ -111,7 +111,7 @@ final class JSendBasicTest extends TestCase
         JSend::decode($json);
     }
 
-    public function testSuccessResponseWithNullData()
+    public function testSuccessResponseWithNullData(): void
     {
         $json     = '{ "status": "success", "data": null }';
         $response = JSend::decode($json);
@@ -120,7 +120,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
 
-    public function testSuccessResponseWithEmptyData()
+    public function testSuccessResponseWithEmptyData(): void
     {
         $json     = '{ "status": "success", "data": [] }';
         $response = JSend::decode($json);
@@ -129,7 +129,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
 
-    public function testFailResponse()
+    public function testFailResponse(): void
     {
         $json = '{
             "status" : "fail",
@@ -142,7 +142,7 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
 
-    public function testGetErrorOnNoneError()
+    public function testGetErrorOnNoneError(): void
     {
         $response = Jsend::decode('{"status": "success", "data": null}');
         $this->expectException(BadMethodCallException::class);
@@ -150,7 +150,7 @@ final class JSendBasicTest extends TestCase
         $response->getError();
     }
 
-    public function testErrorResponse()
+    public function testErrorResponse(): void
     {
         $json = '{
             "status" : "error",
@@ -163,21 +163,21 @@ final class JSendBasicTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($response));
     }
 
-    public function testSuccess()
+    public function testSuccess(): void
     {
         $this->assertTrue(Status::success()->isSuccess());
         $json = '{"status": "success", "data": null}';
         $this->assertJsonStringEqualsJsonString($json, JSend::success(['data' => null]));
     }
 
-    public function testFail()
+    public function testFail(): void
     {
         $this->assertTrue(Status::fail()->isFail());
         $json = '{"status": "fail", "data": null}';
         $this->assertJsonStringEqualsJsonString($json, JSend::fail(['data' => null]));
     }
 
-    public function testError()
+    public function testError(): void
     {
         $this->assertTrue(Status::error()->isError());
         $json = '{"status": "error", "message": ""}';

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -3,7 +3,10 @@
 namespace Demv\JSend\Test;
 
 use Demv\JSend\JSend;
+use Demv\JSend\JSendResponse;
 use Demv\JSend\ResponseFactory;
+use Demv\JSend\Status;
+use Demv\JSend\StatusInterface;
 use PHPUnit\Framework\TestCase;
 
 final class ResponseTest extends TestCase
@@ -49,8 +52,8 @@ final class ResponseTest extends TestCase
         $error->withBody(new DummyStream($json));
         $error->withStatus(501);
 
-        $result           = json_decode($json, true);
-        $result['code']   = $error->getStatusCode();
+        $result         = json_decode($json, true);
+        $result['code'] = $error->getStatusCode();
 
         $response = ResponseFactory::instance()->convert($error);
         $this->assertTrue($response->getStatus()->isError());
@@ -58,5 +61,26 @@ final class ResponseTest extends TestCase
         $this->assertJsonStringEqualsJsonString(json_encode($result), json_encode($response));
         $this->assertEquals('Something is not right...', $response->getError()->getMessage());
         $this->assertEquals($error->getStatusCode(), $response->getError()->getCode());
+    }
+
+    public function testMapping()
+    {
+        $response = new JSendResponse(Status::translate(1), null);
+        $this->assertTrue($response->getStatus()->isSuccess());
+
+        $response = new JSendResponse(Status::translate(0), null);
+        $this->assertTrue($response->getStatus()->isFail());
+
+        $response = new JSendResponse(Status::translate(-1), null);
+        $this->assertTrue($response->getStatus()->isError());
+
+        $response = new JSendResponse(Status::translate(true), null);
+        $this->assertTrue($response->getStatus()->isSuccess());
+
+        $response = new JSendResponse(Status::translate(false), null);
+        $this->assertTrue($response->getStatus()->isFail());
+
+        $response = new JSendResponse(Status::translate(false, [false => StatusInterface::STATUS_ERROR]), null);
+        $this->assertTrue($response->getStatus()->isError());
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -63,7 +63,7 @@ final class ResponseTest extends TestCase
         $this->assertEquals($error->getStatusCode(), $response->getError()->getCode());
     }
 
-    public function testMapping()
+    public function testMapping(): void
     {
         $response = new JSendResponse(Status::translate(1), null);
         $this->assertTrue($response->getStatus()->isSuccess());


### PR DESCRIPTION
 - Added helper functions to simplify the creation of success, fail and error responses
~~- Deprecate use of "new Status()". Since it's idempotent it can be used as singleton to spare object invocations~~ 

@spaceemotion