### PR TITLE
Fix asResponse Header (Content-Type)

### DIFF
--- a/src/AbstractJSendResponse.php
+++ b/src/AbstractJSendResponse.php
@@ -132,6 +132,8 @@ abstract class AbstractJSendResponse implements JSendResponseInterface
     {
         $code = $code ?? JSend::getDefaultHttpStatusCode($this);
 
-        return new Response($code, $headers, json_encode($this));
+        return new Response($code, [
+            'content-type' => 'application/json',
+        ] + $headers, json_encode($this));
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -122,6 +122,12 @@ final class ResponseTest extends TestCase
         $response = JSendResponse::error('Es ist ein Fehler aufgetreten', 404)->asResponse(500);
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertEquals('{"status":"error","message":"Es ist ein Fehler aufgetreten","code":404}', $response->getBody()->getContents());
+
+        $response = JSendResponse::success(['Stimmt der Header?'])->asResponse();
+        $this->assertEquals(['application/json'], $response->getHeader('content-type'));
+
+        $response = JSendResponse::success(['Eigene Header werden übernommen'])->asResponse(null, ['foo' => 'bar']);
+        $this->assertEquals(['bar'], $response->getHeader('foo'));
     }
 
     public function testPsr7ResponseOptionalCode(): void


### PR DESCRIPTION
The (correct) Content-Type was missing, so all responses returned as HTML instead of a real JSON response.